### PR TITLE
Missing exception import

### DIFF
--- a/src/Model/Traits/HasCompositePrimaryKey.php
+++ b/src/Model/Traits/HasCompositePrimaryKey.php
@@ -4,6 +4,7 @@ namespace LaravelTreats\Model\Traits;
 
 use Exception;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
 
 trait HasCompositePrimaryKey
 {


### PR DESCRIPTION
added missing exception import: Illuminate\Database\Eloquent\ModelNotFoundException

i copied this code in my editor and saw you where missing an import, i added it. you probably never ran into this edge case (only happens when you forget to specify all the keys in the find method).